### PR TITLE
find-closest-palette-color.js: Potential bug if alpha is 0

### DIFF
--- a/src/functions/find-closest-palette-color.js
+++ b/src/functions/find-closest-palette-color.js
@@ -19,9 +19,8 @@ const findClosestPaletteColor = (pixel, colorPalette) => {
         }
     })
 
-    if (!closestColor.color[3]) {
-        closestColor.color.push(255) // if no alpha value is present add it.
-    }
+    // if no alpha value is present add it.
+    closestColor.color[3] = closestColor.color[3] ?? 255;
 
     return closestColor.color
 }


### PR DESCRIPTION
Hi,

I want to flag a potential bug:

* I guess you expect the array to have 3 or 4 items.
* `!0` is `true`.
* If the array has 4 items and the 4th (alpha) is `0`, a 5th item will be pushed to the array.
* This is might not cause any bugs, if all other functions don't use this 5th item.

## My fix
* Sets alpha to 255 if the value is `undefined` (or `null`, which isn't expected here).
  * `0 ?? 255` results in `0`. This is different from `0 || 255` which results in `255`. 
* `??` got became available in all browser and NodeJS 14.
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing#browser_compatibility