### PR TITLE
package.json: License is MIT instead of ISC

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Dither images at build time for static site generators.",
   "main": "src/index.js",
   "author": "ShadowfaxRodeo",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "canvas": "^2.8.0"
   }


### PR DESCRIPTION
On NPM, this project looks to be licensed under ISC because that's what it says in package.json.
If I remember correctly, ISC is the default when creating a new project with `npm init`.

https://www.npmjs.com/package/dither-me-this

Looking at this repo, it looks like the author's intention was to license it under the MIT license.